### PR TITLE
Fixed issue where code-server was running as root

### DIFF
--- a/code-server.service
+++ b/code-server.service
@@ -3,6 +3,8 @@ Description=code-server
 After=nginx.service
 
 [Service]
+User=ubuntu
+Group=ubuntu
 Type=simple
 Environment=PASSWORD=saymemyname
 ExecStart=/usr/bin/code-server --bind-addr 127.0.0.1:8080 --user-data-dir /var/lib/code-server --auth password


### PR DESCRIPTION
Added the `User` and `Group` under `[service]` in "code-server.service" file, so that code-server doesn't run as root.